### PR TITLE
Menu and Activity Switching 

### DIFF
--- a/.externalToolBuilders/JNI Builder.launch
+++ b/.externalToolBuilders/JNI Builder.launch
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType">
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="/home/sdague/code/android-ndk-r3/build.sh"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="/home/keith/android-stuff/android-ndk-r4b/build.sh"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="solarsym"/>
 <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="/home/sdague/code/android-ndk-r3"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="/home/keith/android-stuff/android-ndk-r4b"/>
 </launchConfiguration>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	  android:installLocation="auto"
       package="net.dague.astro"
       android:versionCode="5"
       android:versionName="1.4">
     <application android:icon="@drawable/icon" android:label="@string/app_name">
     	<activity android:name=".MainScreen"
-    			android:label="@string/app_name">
-    			<intent-filter>
+    		android:label="@string/app_name">
+     		<intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-    			</activity>
+     	</activity>
         <activity android:name=".JovianSpiral"
-                  android:label="@string/spiral_title">
+			android:label="@string/spiral_title">
     	</activity>
         
         <activity android:name=".RiseSetTimes"
-            android:label="@string/riseset_title">
+            android:label="@string/riseset_title">           
         </activity>
-        
         <activity android:name=".About"
-      	android:label="@string/about_title"
-      	android:theme="@android:style/Theme.Dialog" >
+      		android:label="@string/about_title"
+      		android:theme="@android:style/Theme.Dialog" >
 		</activity>
 		<activity android:name=".Details"
-      	android:theme="@android:style/Theme.Dialog" >
+      		android:theme="@android:style/Theme.Dialog" >
 		</activity>
         
 
     </application>
-<uses-sdk android:minSdkVersion="3" android:targetSdkVersion="7" ></uses-sdk>
+<uses-sdk android:minSdkVersion="3" android:targetSdkVersion="8" ></uses-sdk>
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"></uses-permission>
 
 

--- a/default.properties
+++ b/default.properties
@@ -10,4 +10,4 @@
 # Indicates whether an apk should be generated for each density.
 split.density=false
 # Project target.
-target=Google Inc.:Google APIs:7
+target=Google Inc.:Google APIs:8

--- a/res/menu/menu.xml
+++ b/res/menu/menu.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
+   <item android:id="@+id/riseset"
+      android:title="@string/riseset_title" />
+   <item android:id="@+id/spiral"
+      android:title="@string/spiral_title" />
    <item android:id="@+id/about"
       android:title="@string/about_label"
       android:alphabeticShortcut="@string/about_shortcut" />
+   <item android:id="@+id/quit"
+	  android:title="Quit" />
 </menu>
       

--- a/src/net/dague/astro/JovianSpiral.java
+++ b/src/net/dague/astro/JovianSpiral.java
@@ -87,6 +87,19 @@ public class JovianSpiral extends Activity implements OnClickListener {
 		case R.id.about:
 			startActivity(new Intent(this, About.class));
 		    return true;
+		    
+		case R.id.spiral:
+		    startActivity(new Intent(this, JovianSpiral.class));
+			this.finish();
+		    return true;
+		    
+		case R.id.riseset:
+			startActivity(new Intent(this, RiseSetTimes.class));
+			this.finish();
+			return true;
+			
+		case R.id.quit:
+			this.finish();
 		}
 		
 		return false;

--- a/src/net/dague/astro/RiseSetTimes.java
+++ b/src/net/dague/astro/RiseSetTimes.java
@@ -13,6 +13,7 @@ import net.dague.astro.sim.SolarSim;
 import net.dague.astro.util.TimeUtil;
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.location.Location;
@@ -20,6 +21,9 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 
 public class RiseSetTimes extends Activity implements OnClickListener {
 
@@ -95,6 +99,36 @@ public class RiseSetTimes extends Activity implements OnClickListener {
 //        View exitButton = findViewById(R.id.exit_button);
 //        exitButton.setOnClickListener(this);
     }
+
+    public boolean onOptionsItemSelected(MenuItem item) {
+		switch (item.getItemId()) {
+		case R.id.about:
+			startActivity(new Intent(this, About.class));
+		    return true;
+
+        case R.id.spiral:
+		    startActivity(new Intent(this, JovianSpiral.class));
+			this.finish();
+		    return true;
+		    
+		case R.id.riseset:
+			startActivity(new Intent(this, RiseSetTimes.class));
+			this.finish();
+			return true;
+			
+		case R.id.quit:
+			this.finish();
+		}
+		
+		return false;
+	}
+
+	public boolean onCreateOptionsMenu(Menu menu) {
+		   super.onCreateOptionsMenu(menu);
+		   MenuInflater inflater = getMenuInflater();
+		   inflater.inflate(R.menu.menu, menu);
+		   return true;
+		}
 
 	private double[] getGPS() {  
 


### PR DESCRIPTION
Here's the set of changes I made to the code.  I merged my changes to yesterday's code into the changed code that you committed today.  I've tested the changed code both in an emulator and on my MotoDroid (Froyo).  I haven't found any bugs but the workflow is a little weird with the MainScreen being implemented.  I didn't change any code in that so the menu doesn't appear in that Activity and when you select Quit from the menu in the Jovian Spiral or Rise and Set Times Activities, you'll be sent back to the Main Screen since it didn't call this.finish() after it spawned the new Activity.  So Quit and the Back button on the device essentially act the same which can be misleading to a user.  

I like the Main Screen and the changes to the Rise and Set Times page (removing "Rise:" and "Set:" labels as well as the 24hr format).  

I'm a firm believer that apps should have a Quit function so the user doesn't have to kill it with something like ATK.  Also since this app takes over 3MB I made changes to allow for moving it to the SD card.  Basically all you need to do is change the target SDK to 8 (2.2) rather than 7 (2.1) and add android:installLocation="auto" to the manifest so the user can move it.  

I'm not much of a Java developer (taught myself back in the days of Java 1.1 and barely used it until recently) and this is only the second Android App I've coded for so I won't take it personally if you don't use any of my input and I'm certainly not going to maintain my own fork of your project if you don't.  I mostly got involved because I wanted the Rise and Set functionality, didn't have the patience to wait for it, and welcomed the excuse to learn some Java/Android coding.

Thanks again for writing this and making it open source.
-Keith

p.s. Watch out for the JNI Builder.launch changes that you don't need.
